### PR TITLE
[fix] dependency fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>


### PR DESCRIPTION
Some dependencies are transitively introduced via the
connector4java dependency. this will break compatibility with the new
dependency-reduced connector version (1.2), so fixing this upfront now.

see also https://github.com/osiam/connector4java/pull/103
