### PR TITLE
MySQL: disable DNS lookups

### DIFF
--- a/src/main/docker/mysql/Dockerfile
+++ b/src/main/docker/mysql/Dockerfile
@@ -3,6 +3,8 @@ FROM mysql:5.7
 RUN cp -p /usr/share/zoneinfo/${user.timezone} /etc/localtime
 RUN echo "${user.timezone}" > /etc/timezone
 
+RUN echo '[mysqld]\nskip-name-resolve' > /etc/mysql/conf.d/no-dns.cnf
+
 ENV MYSQL_ROOT_PASSWORD mysql_root_password
 ENV MYSQL_DATABASE ong
 ENV MYSQL_USER ong


### PR DESCRIPTION
I had some issues running the MySQL based tests. Turns out that MySQL does a reverse DNS lookup for each client connection, which ran into timeouts on my machine at home. This resulted in all tests failing and an execution time of several hours(!). This PR disables DNS lookups using the [`skip-name-resolve`](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_skip-name-resolve) configuration option.