### PR TITLE
Use the real self-administration client

### DIFF
--- a/src/test/resources/addon-self-administration-configuration/addon-self-administration.properties
+++ b/src/test/resources/addon-self-administration-configuration/addon-self-administration.properties
@@ -19,8 +19,8 @@ org.osiam.html.dependencies.bootstrap=http://getbootstrap.com/dist/css/bootstrap
 org.osiam.html.dependencies.angular=http://code.angularjs.org/1.2.0-rc.3/angular.min.js
 org.osiam.html.dependencies.jquery=http://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js
 
-org.osiam.addon-self-administration.client.id=example-client
-org.osiam.addon-self-administration.client.secret=secret
+org.osiam.addon-self-administration.client.id=addon-self-administration-client
+org.osiam.addon-self-administration.client.secret=super-secret
 
 org.osiam.addon-self-administration.registration.activation-token-timeout=1d 10h 30m 15s
 org.osiam.addon-self-administration.change-email.confirmation-token-timeout=1d 15s

--- a/src/test/resources/database_seed_registration.xml
+++ b/src/test/resources/database_seed_registration.xml
@@ -46,6 +46,17 @@
     <osiam_client_scopes id="100004" scope="POST"/>
     <osiam_client_scopes id="100004" scope="PATCH"/>
 
+    <osiam_client internal_id="100005" id="addon-self-administration-client"
+                  redirect_uri="http://localhost:8180/addon-self-administration" client_secret="super-secret"
+                  accesstokenvalidityseconds="300" refreshtokenvalidityseconds="0" validityinseconds="0"
+                  implicit_approval="false"/>
+    <osiam_client_scopes id="100005" scope="GET"/>
+    <osiam_client_scopes id="100005" scope="POST"/>
+    <osiam_client_scopes id="100005" scope="PUT"/>
+    <osiam_client_scopes id="100005" scope="PATCH"/>
+    <osiam_client_scopes id="100005" scope="DELETE"/>
+    <osiam_client_grants id="100005" grants="client_credentials"/>
+
     <scim_meta id="100004" created="2011-10-10 00:00:00.0" lastmodified="2011-10-10 00:00:00.0" resourcetype="User"/>
     <scim_meta id="100053" created="2013-07-31 21:43:18.0" lastmodified="2013-07-31 21:43:18.0" resourcetype="Group"/>
     <scim_meta id="100061" created="2011-10-10 00:00:00.0" lastmodified="2011-10-10 00:00:00.0" resourcetype="User"/>


### PR DESCRIPTION
Currently the self-admin tests are running with the example-client. This commit adds the "real" self-admin client (as defined in the SQL scripts) and configures the self-administration to use it.