### PR TITLE
All tests need to setup specific access token

### DIFF
--- a/src/test/java/org/osiam/client/integration/SearchByExtensionIT.java
+++ b/src/test/java/org/osiam/client/integration/SearchByExtensionIT.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osiam.client.AbstractIntegrationTestBase;
@@ -49,6 +50,11 @@ import com.github.springtestdbunit.annotation.DatabaseTearDown;
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class SearchByExtensionIT extends AbstractIntegrationTestBase {
+
+    @Before
+    public void setup() {
+        retrieveAccessTokenForMarissa();
+    }
 
     @Test
     @DatabaseSetup(value = "/database_seeds/SearchByExtensionIT/extensions.xml")

--- a/src/test/java/org/osiam/client/regression/BT22IT.java
+++ b/src/test/java/org/osiam/client/regression/BT22IT.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertThat;
 import java.io.UnsupportedEncodingException;
 import java.util.Locale;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osiam.client.AbstractIntegrationTestBase;
@@ -59,6 +60,11 @@ public class BT22IT extends AbstractIntegrationTestBase {
 
     private static final String FIELD = "gender";
     private static final String FIELD_WRONG_CASE = FIELD.toUpperCase(Locale.ENGLISH);
+
+    @Before
+    public void setup() {
+        retrieveAccessTokenForMarissa();
+    }
 
     @Test
     public void searching_for_user_with_filter_on_extension_field_same_case() throws UnsupportedEncodingException {
@@ -98,5 +104,4 @@ public class BT22IT extends AbstractIntegrationTestBase {
 
         assertThat(result.getTotalResults(), is(equalTo(3L)));
     }
-
 }

--- a/src/test/java/org/osiam/client/regression/Bug251.java
+++ b/src/test/java/org/osiam/client/regression/Bug251.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osiam.client.AbstractIntegrationTestBase;
@@ -27,6 +28,11 @@ import com.github.springtestdbunit.annotation.DatabaseTearDown;
 @DatabaseSetup(value = "/database_seeds/Bug251/database_seed.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class Bug251 extends AbstractIntegrationTestBase {
+
+    @Before
+    public void setup() {
+        retrieveAccessTokenForMarissa();
+    }
 
     @Test
     public void sorting_by_formatted_does_not_remove_users_without_a_name_set_from_result() {


### PR DESCRIPTION
To check if every test creates its own access token, just nullify the access token object in [AbstractIntegrationTestBase](https://github.com/osiam/connector4java-integration-tests/blob/master/src/test/java/org/osiam/client/AbstractIntegrationTestBase.java#L37):

```java
@After
public void destroyToken() {
    accessToken = null;
}
```

BTW: I think it's not necessary to create a new one for every test, [a static one should do the trick](https://github.com/osiam/connector4java-integration-tests/blob/master/src/test/java/org/osiam/client/AbstractIntegrationTestBase.java#L51), right?