### PR TITLE
[fix] Quote column names

### DIFF
--- a/src/test/groovy/org/osiam/test/integration/AbstractIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/AbstractIT.groovy
@@ -80,10 +80,8 @@ abstract class AbstractIT extends Specification {
 
         // Load Spring context configuration.
         ApplicationContext ac = new ClassPathXmlApplicationContext('context.xml')
-        // Get dataSource configuration.
-        DataSource dataSource = (DataSource) ac.getBean('dataSource')
         // Establish database connection.
-        IDatabaseConnection connection = new DatabaseDataSourceConnection(dataSource)
+        IDatabaseConnection connection = (IDatabaseConnection) ac.getBean('dbUnitDatabaseConnection')
         // Load the initialization data from file.
         IDataSet initData = new FlatXmlDataSetBuilder().build(ac.getResource(seedFileName).getFile())
 

--- a/src/test/resources/context.xml
+++ b/src/test/resources/context.xml
@@ -37,6 +37,15 @@
         <property name="password" value="${org.osiam.integration-tests.db.password}"/>
     </bean>
 
+    <bean id="dbUnitDatabaseConfig" class="com.github.springtestdbunit.bean.DatabaseConfigBean">
+        <property name="escapePattern" value="${org.osiam.integration-tests.db.escapestring}" />
+    </bean>
+
+    <bean id="dbUnitDatabaseConnection" class="com.github.springtestdbunit.bean.DatabaseDataSourceConnectionFactoryBean">
+        <property name="dataSource" ref="dataSource" />
+        <property name="databaseConfig" ref="dbUnitDatabaseConfig"/>
+    </bean>
+
     <bean id="entityManagerFactory"  class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="packagesToScan" value="org.osiam.client"/>

--- a/src/test/resources/integration-tests_mysql.properties
+++ b/src/test/resources/integration-tests_mysql.properties
@@ -4,3 +4,4 @@ org.osiam.integration-tests.db.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 org.osiam.integration-tests.db.url=jdbc:mysql://localhost:13306/ong
 org.osiam.integration-tests.db.username=ong
 org.osiam.integration-tests.db.password=b4s3dg0d
+org.osiam.integration-tests.db.escapestring=`?`

--- a/src/test/resources/integration-tests_pg.properties
+++ b/src/test/resources/integration-tests_pg.properties
@@ -4,3 +4,4 @@ org.osiam.integration-tests.db.dialect=org.hibernate.dialect.PostgresPlusDialect
 org.osiam.integration-tests.db.url=jdbc:postgresql://localhost:15432/ong
 org.osiam.integration-tests.db.username=ong
 org.osiam.integration-tests.db.password=b4s3dg0d
+org.osiam.integration-tests.db.escapestring=\"?\"


### PR DESCRIPTION
This commit makes dbUnit quote the column names using the database
specific quote character. It is necessary to enable a smooth
transition to the new naming scheme.