### PR TITLE
Bump MySQL JDBC driver version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.35</version>
+            <version>5.1.36</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This fixes a backwards incompatibility introduced with MySQL 5.7.8.