### PR TITLE
Remove HTML accept type test

### DIFF
--- a/src/test/groovy/org/osiam/test/integration/ControllerIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/ControllerIT.groovy
@@ -87,7 +87,6 @@ class ControllerIT extends AbstractIT {
         "e"      | "/Users"                       | ContentType.ANY    | 200                  | "application/json;charset=UTF-8"
         "f"      | "/Users"                       | ContentType.TEXT   | 406                  | null
         "g"      | "/Users"                       | ContentType.BINARY | 406                  | null
-        "h"      | "/Users"                       | ContentType.HTML   | 406                  | null
         "i"      | "/Users"                       | ContentType.URLENC | 406                  | null
         "j"      | "/Users"                       | ContentType.XML    | 406                  | null
         "k"      | "/Users"                       | "invalid"          | 406                  | null


### PR DESCRIPTION
We don't really care what happens when a client requests a response type
of `text/html`. OSIAM's interface is only defined for accept types of
`application/json`. FWIW: Spring Boot responds with a white label error
page in that case. We can think about adding a more sophisticated error
page later.