### PR TITLE
Remove deprecated properties from configuration

### DIFF
--- a/src/test/resources/resource-server-configuration/resource-server_mysql.properties
+++ b/src/test/resources/resource-server-configuration/resource-server_mysql.properties
@@ -5,9 +5,6 @@ org.osiam.resource-server.db.url=jdbc:mysql://mysql:3306/ong
 org.osiam.resource-server.db.username=ong
 org.osiam.resource-server.db.password=b4s3dg0d
 
-# OSIAM resource server configuration
-org.osiam.resource-server.profiling=false
-
 # Home URL (needed for self reference)
 org.osiam.resource-server.home=http://localhost:8180/osiam-resource-server
 

--- a/src/test/resources/resource-server-configuration/resource-server_pg.properties
+++ b/src/test/resources/resource-server-configuration/resource-server_pg.properties
@@ -5,9 +5,6 @@ org.osiam.resource-server.db.url=jdbc:postgresql://postgres:5432/ong
 org.osiam.resource-server.db.username=ong
 org.osiam.resource-server.db.password=b4s3dg0d
 
-# OSIAM resource server configuration
-org.osiam.resource-server.profiling=false
-
 # Home URL (needed for self reference)
 org.osiam.resource-server.home=http://localhost:8180/osiam-resource-server
 


### PR DESCRIPTION
Since the removal of the self-made profiling solution from the
resource-server in osiam/resource-server#63 the configuration property 
to enable it is deprecated and hence removed.