### PR TITLE
Clean up testing for exceptions

### DIFF
--- a/src/test/groovy/org/osiam/test/integration/ControllerIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/ControllerIT.groovy
@@ -98,7 +98,7 @@ class ControllerIT extends AbstractIT {
     }
 
     @Unroll
-    def "REGT-002-#testCase: A search operation on the Users endpoint with search string #searchString should return HTTP status code #expectedResponseCode."() {
+    def 'REGT-002-#testCase: A search operation on the Users endpoint with search string #searchString should return HTTP status code #expectedResponseCode.'() {
         given: "a valid access token"
         AccessToken validAccessToken = OSIAM_CONNECTOR.retrieveAccessToken(Scope.ADMIN)
 
@@ -144,24 +144,24 @@ class ControllerIT extends AbstractIT {
         'g'      | 'userName lt "n"'                           | 200                  | null                      // String
         'h'      | 'userName le "m"'                           | 200                  | null                      // String
         'i'      | 'emails.type eq "work"'                     | 200                  | null                      // Enum (EmailEntity)
-        'j'      | 'emails.type co "work"'                     | 409                  | 'CONFLICT'                 // Enum (EmailEntity)
-        'k'      | 'emails.type sw "work"'                     | 409                  | 'CONFLICT'                 // Enum (EmailEntity)
+        'j'      | 'emails.type co "work"'                     | 400                  | 'BAD_REQUEST'             // Enum (EmailEntity)
+        'k'      | 'emails.type sw "work"'                     | 400                  | 'BAD_REQUEST'             // Enum (EmailEntity)
         'l'      | 'emails.type pr'                            | 200                  | null                      // Enum (EmailEntity)
-        'm'      | 'emails.type gt "work"'                     | 409                  | 'CONFLICT'                 // Enum (EmailEntity)
-        'n'      | 'emails.type ge "work"'                     | 409                  | 'CONFLICT'                 // Enum (EmailEntity)
-        'o'      | 'emails.type lt "work"'                     | 409                  | 'CONFLICT'                 // Enum (EmailEntity)
-        'p'      | 'emails.type le "work"'                     | 409                  | 'CONFLICT'                 // Enum (EmailEntity)
+        'm'      | 'emails.type gt "work"'                     | 400                  | 'BAD_REQUEST'             // Enum (EmailEntity)
+        'n'      | 'emails.type ge "work"'                     | 400                  | 'BAD_REQUEST'             // Enum (EmailEntity)
+        'o'      | 'emails.type lt "work"'                     | 400                  | 'BAD_REQUEST'             // Enum (EmailEntity)
+        'p'      | 'emails.type le "work"'                     | 400                  | 'BAD_REQUEST'             // Enum (EmailEntity)
         'q'      | 'active eq "true"'                          | 200                  | null                      // boolean
-        'r'      | 'active co "true"'                          | 409                  | 'CONFLICT'                 // boolean
-        's'      | 'active sw "true"'                          | 409                  | 'CONFLICT'                 // boolean
+        'r'      | 'active co "true"'                          | 400                  | 'BAD_REQUEST'             // boolean
+        's'      | 'active sw "true"'                          | 400                  | 'BAD_REQUEST'             // boolean
         't'      | 'active pr'                                 | 200                  | null                      // boolean
-        'u'      | 'active gt "true"'                          | 409                  | 'CONFLICT'                 // boolean
-        'v'      | 'active ge "true"'                          | 409                  | 'CONFLICT'                 // boolean
-        'w'      | 'active lt "true"'                          | 409                  | 'CONFLICT'                 // boolean
-        'x'      | 'active le "true"'                          | 409                  | 'CONFLICT'                 // boolean
-        'y'      | 'meta.created co "2013-08-08T19:46:20.638"' | 409                  | 'CONFLICT'                // Date
-        'z'      | 'meta.created sw "2013-08-08T1"'            | 409                  | 'CONFLICT'                // Date
-        'za'     | 'active pr "true"'                          | 409                  | 'CONFLICT'                // pr with value
+        'u'      | 'active gt "true"'                          | 400                  | 'BAD_REQUEST'             // boolean
+        'v'      | 'active ge "true"'                          | 400                  | 'BAD_REQUEST'             // boolean
+        'w'      | 'active lt "true"'                          | 400                  | 'BAD_REQUEST'             // boolean
+        'x'      | 'active le "true"'                          | 400                  | 'BAD_REQUEST'             // boolean
+        'y'      | 'meta.created co "2013-08-08T19:46:20.638"' | 400                  | 'BAD_REQUEST'             // Date
+        'z'      | 'meta.created sw "2013-08-08T1"'            | 400                  | 'BAD_REQUEST'             // Date
+        'za'     | 'active pr "true"'                          | 400                  | 'BAD_REQUEST'             // pr with value
     }
 
     def "REGT-005: A search filter String matching two users should return totalResults=2 and two unique Resource elements."() {

--- a/src/test/java/org/osiam/client/AccessTokenValidationIT.java
+++ b/src/test/java/org/osiam/client/AccessTokenValidationIT.java
@@ -62,7 +62,6 @@ public class AccessTokenValidationIT extends AbstractIntegrationTestBase {
     public void invalid_access_token_can_be_recognized() {
         AccessToken invalidAccessToken = new AccessToken.Builder("invalid").build();
         OSIAM_CONNECTOR.validateAccessToken(invalidAccessToken);
-        fail("Exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/AdminScopeIT.java
+++ b/src/test/java/org/osiam/client/AdminScopeIT.java
@@ -23,20 +23,10 @@
 
 package org.osiam.client;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,27 +36,26 @@ import org.osiam.client.oauth.Scope;
 import org.osiam.client.query.Query;
 import org.osiam.client.query.QueryBuilder;
 import org.osiam.client.user.BasicUser;
-import org.osiam.resources.scim.Email;
-import org.osiam.resources.scim.Group;
-import org.osiam.resources.scim.MemberRef;
-import org.osiam.resources.scim.SCIMSearchResult;
-import org.osiam.resources.scim.UpdateGroup;
-import org.osiam.resources.scim.UpdateUser;
-import org.osiam.resources.scim.User;
+import org.osiam.resources.scim.*;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup("/database_seed_admin_scope.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class AdminScopeIT extends AbstractIntegrationTestBase {
@@ -406,7 +395,6 @@ public class AdminScopeIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.revokeAccessToken(accessToken);
 
         OSIAM_CONNECTOR.validateAccessToken(accessToken);
-        fail("Exception expected");
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -416,7 +404,6 @@ public class AdminScopeIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.revokeAllAccessTokens(OWN_USER_ID, accessToken);
 
         OSIAM_CONNECTOR.validateAccessToken(accessToken);
-        fail("Exception expected");
     }
 
     @Test
@@ -437,7 +424,6 @@ public class AdminScopeIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.revokeAllAccessTokens(OTHER_USER_ID, accessToken);
 
         OSIAM_CONNECTOR.validateAccessToken(accessTokenOfOtherUser);
-        fail("Exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/EditGroupServiceIT.java
+++ b/src/test/java/org/osiam/client/EditGroupServiceIT.java
@@ -23,14 +23,10 @@
 
 package org.osiam.client;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.UUID;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,15 +42,15 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup(value = "/database_seeds/EditGroupServiceIT/groups.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class EditGroupServiceIT extends AbstractIntegrationTestBase {
@@ -74,14 +70,12 @@ public class EditGroupServiceIT extends AbstractIntegrationTestBase {
     public void create_group_without_displayName_raises_exception() {
         group = new Group.Builder().build();
         OSIAM_CONNECTOR.createGroup(group, accessToken);
-        fail("Exception expected");
     }
 
     @Test(expected = ConflictException.class)
     public void create_group_with_empty_displayName_raises_exception() {
         group = new Group.Builder("").build();
         OSIAM_CONNECTOR.createGroup(group, accessToken);
-        fail("Exception expected");
     }
 
     @Test(expected = ConflictException.class)
@@ -89,7 +83,6 @@ public class EditGroupServiceIT extends AbstractIntegrationTestBase {
         String existingGroupName = "parent_group";
         group = new Group.Builder(existingGroupName).build();
         OSIAM_CONNECTOR.createGroup(group, accessToken);
-        fail("Exception expected");
     }
 
     @Test
@@ -115,7 +108,6 @@ public class EditGroupServiceIT extends AbstractIntegrationTestBase {
         Group createdGroup = OSIAM_CONNECTOR.createGroup(group, accessToken);
         assertThat(createdGroup.getId(), not(equalTo(INVALID_ID))); // This might fail once every 8 billion years
         OSIAM_CONNECTOR.getGroup(newId, accessToken);
-        fail("Exception expected");
     }
 
     @Test
@@ -135,13 +127,11 @@ public class EditGroupServiceIT extends AbstractIntegrationTestBase {
 
         OSIAM_CONNECTOR.getGroup(newId, accessToken);
 
-        fail("Exception expected");
     }
 
     @Test(expected = NoResultException.class)
     public void delete_non_existing_group_raises_exception() throws Exception {
         OSIAM_CONNECTOR.deleteGroup(INVALID_ID, accessToken);
-        fail("Exception ");
     }
 
     private Group findSingleGroupByQuery(Query query) {

--- a/src/test/java/org/osiam/client/EditUserServiceIT.java
+++ b/src/test/java/org/osiam/client/EditUserServiceIT.java
@@ -23,18 +23,10 @@
 
 package org.osiam.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,25 +36,23 @@ import org.osiam.client.exception.UnauthorizedException;
 import org.osiam.client.oauth.Scope;
 import org.osiam.client.query.Query;
 import org.osiam.client.query.QueryBuilder;
-import org.osiam.resources.scim.Address;
-import org.osiam.resources.scim.Email;
-import org.osiam.resources.scim.Name;
-import org.osiam.resources.scim.SCIMSearchResult;
-import org.osiam.resources.scim.User;
+import org.osiam.resources.scim.*;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup(value = "/database_seed.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class EditUserServiceIT extends AbstractIntegrationTestBase {
@@ -87,14 +77,12 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
     public void create_user_with_no_username_raises_exception() {
         initializeUserWithNoUserName();
         createUser();
-        fail("Exception expected");
     }
 
     @Test(expected = ConflictException.class)
     public void create_user_with_existing_username_raises_exception() {
         initializeUserWithExistingUserName();
         createUser();
-        fail("Exception expected");
     }
 
     @Test
@@ -174,7 +162,6 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
         whenUserIsDeleted();
         assertThatUserIsRemoveFromServer();
         whenUserIsDeleted();
-        fail();
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -183,7 +170,6 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
         givenAValidUserIDForDeletion();
         givenAnInvalidAccessToken();
         whenUserIsDeleted();
-        fail();
     }
 
     private void initializeUserWithNoUserName() {
@@ -275,7 +261,7 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
         if ((expectedMultiValuedAttributes == null || expectedMultiValuedAttributes
                 .size() == 0)
                 && (actualMultiValuedAttributes == null || actualMultiValuedAttributes
-                        .size() == 0)) {
+                .size() == 0)) {
             return;
         }
         assertEquals(expectedMultiValuedAttributes.size(),
@@ -298,7 +284,7 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
     }
 
     private Email getMultiAttributeWithValue(List<Email> multiValuedAttributes,
-            String expectedValue) {
+                                             String expectedValue) {
         Email email = null;
         for (Email actAttribute : multiValuedAttributes) {
             if (actAttribute.getValue().equals(expectedValue)) {
@@ -321,7 +307,7 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
     }
 
     private void assertEqualsAddresses(List<Address> expectedAddresses,
-            List<Address> actualAddresses) {
+                                       List<Address> actualAddresses) {
         assertEquals(expectedAddresses.size(), actualAddresses.size());
         for (int count = 0; count < expectedAddresses.size(); count++) {
             Address expectedAddress = expectedAddresses.get(count);

--- a/src/test/java/org/osiam/client/ErrorMessagesIT.java
+++ b/src/test/java/org/osiam/client/ErrorMessagesIT.java
@@ -23,13 +23,14 @@
 
 package org.osiam.client;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.UUID;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.osiam.client.exception.ConflictException;
 import org.osiam.client.exception.NoResultException;
@@ -44,18 +45,21 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup(value = "/database_seed.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class ErrorMessagesIT extends AbstractIntegrationTestBase {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -67,14 +71,11 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void retrieving_non_existing_User_returns_correct_error_message() {
-        try {
-            OSIAM_CONNECTOR.getUser(UUID.randomUUID().toString(), accessToken);
-            fail("expected exception");
-        } catch (NoResultException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("User"));
-            assertTrue(errorMessage.contains("not found"));
-        }
+        thrown.expect(NoResultException.class);
+        thrown.expectMessage(startsWith("User"));
+        thrown.expectMessage(containsString("not found"));
+
+        OSIAM_CONNECTOR.getUser(UUID.randomUUID().toString(), accessToken);
     }
 
     /**
@@ -82,14 +83,11 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void retrieving_non_existing_Group_returns_correct_error_message() {
-        try {
-            OSIAM_CONNECTOR.getGroup(UUID.randomUUID().toString(), accessToken);
-            fail("expected exception");
-        } catch (NoResultException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("Group"));
-            assertTrue(errorMessage.contains("not found"));
-        }
+        thrown.expect(NoResultException.class);
+        thrown.expectMessage(startsWith("Group"));
+        thrown.expectMessage(containsString("not found"));
+
+        OSIAM_CONNECTOR.getGroup(UUID.randomUUID().toString(), accessToken);
     }
 
     /**
@@ -97,14 +95,11 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void retrieving_User_with_Group_id_returns_correct_error_message() {
-        try {
-            OSIAM_CONNECTOR.getUser("7c198d82-f03b-4fa8-806c-16b26172bba5", accessToken);
-            fail("expected exception");
-        } catch (NoResultException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("User"));
-            assertTrue(errorMessage.contains("not found"));
-        }
+        thrown.expect(NoResultException.class);
+        thrown.expectMessage(startsWith("User"));
+        thrown.expectMessage(containsString("not found"));
+
+        OSIAM_CONNECTOR.getUser("7c198d82-f03b-4fa8-806c-16b26172bba5", accessToken);
     }
 
     /**
@@ -112,15 +107,12 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_user_without_userName_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("userName"));
+        thrown.expectMessage(containsString("mandatory"));
+
         User user = new User.Builder().build();
-        try {
-            OSIAM_CONNECTOR.createUser(user, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("userName"));
-            assertTrue(errorMessage.contains("mandatory"));
-        }
+        OSIAM_CONNECTOR.createUser(user, accessToken);
     }
 
     /**
@@ -128,15 +120,12 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_group_without_displayName_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("displayName"));
+        thrown.expectMessage(containsString("mandatory"));
+
         Group group = new Group.Builder().build();
-        try {
-            OSIAM_CONNECTOR.createGroup(group, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("displayName"));
-            assertTrue(errorMessage.contains("mandatory"));
-        }
+        OSIAM_CONNECTOR.createGroup(group, accessToken);
     }
 
     /**
@@ -144,16 +133,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_user_with_existing_userName_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("user"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingUserName = "jcambell";
         User user = new User.Builder(existingUserName).build();
-        try {
-            OSIAM_CONNECTOR.createUser(user, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("user"));
-            assertTrue(errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.createUser(user, accessToken);
     }
 
     /**
@@ -161,15 +147,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_user_with_existing_external_id_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("user"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingExternalId = "cmiller";
         User user = new User.Builder("newUser").setExternalId(existingExternalId).build();
-        try {
-            OSIAM_CONNECTOR.createUser(user, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("user") && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.createUser(user, accessToken);
     }
 
     /**
@@ -178,15 +162,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void update_user_with_existing_userName_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("user"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingUserName = "jcambell";
         UpdateUser updateUser = new UpdateUser.Builder().updateUserName(existingUserName).build();
-        try {
-            OSIAM_CONNECTOR.updateUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", updateUser, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("user") && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.updateUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", updateUser, accessToken);
     }
 
     /**
@@ -195,15 +177,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void update_group_with_existing_displayName_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("group"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingUserName = "test_group10";
         UpdateGroup updateUser = new UpdateGroup.Builder().updateDisplayName(existingUserName).build();
-        try {
-            OSIAM_CONNECTOR.updateGroup("0cb908cf-81a9-4966-803f-a3eb92968bb4", updateUser, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("group") && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.updateGroup("0cb908cf-81a9-4966-803f-a3eb92968bb4", updateUser, accessToken);
     }
 
     /**
@@ -212,15 +192,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void update_user_with_existing_external_id_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("user"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingExternalId = "cmiller";
         UpdateUser updateUser = new UpdateUser.Builder().updateExternalId(existingExternalId).build();
-        try {
-            OSIAM_CONNECTOR.updateUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", updateUser, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("user") && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.updateUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", updateUser, accessToken);
     }
 
     /**
@@ -229,15 +207,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void update_group_with_existing_external_id_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("group"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingExternalId = "cmiller";
         UpdateGroup updateUser = new UpdateGroup.Builder().updateExternalId(existingExternalId).build();
-        try {
-            OSIAM_CONNECTOR.updateGroup("69e1a5dc-89be-4343-976c-b5541af249f4", updateUser, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("group") && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.updateGroup("69e1a5dc-89be-4343-976c-b5541af249f4", updateUser, accessToken);
     }
 
     /**
@@ -246,16 +222,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void replace_user_with_existing_username_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("user"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingUsername = "cmiller";
-        User user = new User.Builder(existingUsername)
-                .build();
-        try {
-            OSIAM_CONNECTOR.replaceUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", user, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("user") && errorMessage.contains("already taken"));
-        }
+        User user = new User.Builder(existingUsername).build();
+        OSIAM_CONNECTOR.replaceUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", user, accessToken);
     }
 
     /**
@@ -264,16 +237,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void replace_user_with_existing_external_id_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("user"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingExternalId = "cmiller";
-        User user = new User.Builder("newUser").setExternalId(existingExternalId)
-                .build();
-        try {
-            OSIAM_CONNECTOR.replaceUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", user, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("user") && errorMessage.contains("already taken"));
-        }
+        User user = new User.Builder("newUser").setExternalId(existingExternalId).build();
+        OSIAM_CONNECTOR.replaceUser("aba67300-74f1-4e51-a68a-0a6c5c45b79c", user, accessToken);
     }
 
     /**
@@ -282,16 +252,13 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void replace_group_with_existing_displayname_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("group"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingDisplayName = "test_group02";
-        Group group = new Group.Builder(existingDisplayName)
-                .setId("69e1a5dc-89be-4343-976c-b5541af249f4").build();
-        try {
-            OSIAM_CONNECTOR.replaceGroup("69e1a5dc-89be-4343-976c-b5541af249f4", group, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("group") && errorMessage.contains("already taken"));
-        }
+        Group group = new Group.Builder(existingDisplayName).setId("69e1a5dc-89be-4343-976c-b5541af249f4").build();
+        OSIAM_CONNECTOR.replaceGroup("69e1a5dc-89be-4343-976c-b5541af249f4", group, accessToken);
     }
 
     /**
@@ -300,16 +267,14 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void replace_group_with_existing_external_id_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("group"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingExternalId = "cmiller";
-        Group group = new Group.Builder("newGroupr").setExternalId(existingExternalId)
+        Group group = new Group.Builder("newGroup").setExternalId(existingExternalId)
                 .setId("69e1a5dc-89be-4343-976c-b5541af249f4").build();
-        try {
-            OSIAM_CONNECTOR.replaceGroup("69e1a5dc-89be-4343-976c-b5541af249f4", group, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("group") && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.replaceGroup("69e1a5dc-89be-4343-976c-b5541af249f4", group, accessToken);
     }
 
     /**
@@ -317,16 +282,14 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_group_with_existing_displayName_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("group"));
+        thrown.expectMessage(containsString("displayname"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingGroupName = "test_group02";
         Group group = new Group.Builder(existingGroupName).build();
-        try {
-            OSIAM_CONNECTOR.createGroup(group, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("group") && errorMessage.contains("displayname")
-                    && errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.createGroup(group, accessToken);
     }
 
     /**
@@ -334,17 +297,14 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_group_with_existing_external_id_returns_correct_error_message() {
+        thrown.expect(ConflictException.class);
+        thrown.expectMessage(containsString("group"));
+        thrown.expectMessage(containsString("externalId"));
+        thrown.expectMessage(containsString("already taken"));
+
         String existingGroupName = "newGroup";
         Group group = new Group.Builder(existingGroupName).setExternalId("cmiller").build();
-        try {
-            OSIAM_CONNECTOR.createGroup(group, accessToken);
-            fail("expected exception");
-        } catch (ConflictException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("group"));
-            assertTrue(errorMessage.contains("externalId"));
-            assertTrue(errorMessage.contains("already taken"));
-        }
+        OSIAM_CONNECTOR.createGroup(group, accessToken);
     }
 
     /**
@@ -352,17 +312,15 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void login_with_wrong_client_credentials() {
+        thrown.expect(UnauthorizedException.class);
+        thrown.expectMessage(containsString("Bad credentials"));
+
         final OsiamConnector connectorWithWrongSecret = new OsiamConnector.Builder().
                 setAuthServerEndpoint(AUTH_ENDPOINT_ADDRESS).
                 setResourceServerEndpoint(RESOURCE_ENDPOINT_ADDRESS).
                 setClientId("example-client").
                 setClientSecret("wrongsecret")
                 .build();
-        try {
-            connectorWithWrongSecret.retrieveAccessToken();
-        } catch (UnauthorizedException e) {
-            String errorMessage = e.getMessage();
-            assertTrue(errorMessage.contains("Bad credentials"));
-        }
+        connectorWithWrongSecret.retrieveAccessToken();
     }
 }

--- a/src/test/java/org/osiam/client/GroupMembershipIT.java
+++ b/src/test/java/org/osiam/client/GroupMembershipIT.java
@@ -69,8 +69,6 @@ public class GroupMembershipIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.deleteUser(USER_UUID, accessToken);
 
         OSIAM_CONNECTOR.getUser(USER_UUID, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test
@@ -86,8 +84,6 @@ public class GroupMembershipIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.deleteGroup(MEMBER_GROUP_UUID, accessToken);
 
         OSIAM_CONNECTOR.getGroup(MEMBER_GROUP_UUID, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/GroupServiceIT.java
+++ b/src/test/java/org/osiam/client/GroupServiceIT.java
@@ -101,6 +101,5 @@ public class GroupServiceIT extends AbstractIntegrationTestBase {
     @Test(expected = NoResultException.class)
     public void get_an_invalid_group_raises_exception() throws Exception {
         OSIAM_CONNECTOR.getGroup(INVALID_ID, accessToken);
-        fail("Exception expected");
     }
 }

--- a/src/test/java/org/osiam/client/LoginClientCredentialsIT.java
+++ b/src/test/java/org/osiam/client/LoginClientCredentialsIT.java
@@ -68,7 +68,6 @@ public class LoginClientCredentialsIT extends AbstractIntegrationTestBase {
                 .build();
         connectorWithWrongSecret.retrieveAccessToken();
 
-        fail("Exception expected");
     }
 
 }

--- a/src/test/java/org/osiam/client/LoginOAuth2IT.java
+++ b/src/test/java/org/osiam/client/LoginOAuth2IT.java
@@ -299,7 +299,6 @@ public class LoginOAuth2IT extends AbstractIntegrationTestBase {
         givenAuthCode();
         givenAccessTokenUsingAuthCode();
         givenAccessTokenUsingAuthCode();
-        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/MeScopeIT.java
+++ b/src/test/java/org/osiam/client/MeScopeIT.java
@@ -23,18 +23,10 @@
 
 package org.osiam.client;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,26 +37,26 @@ import org.osiam.client.oauth.Scope;
 import org.osiam.client.query.Query;
 import org.osiam.client.query.QueryBuilder;
 import org.osiam.client.user.BasicUser;
-import org.osiam.resources.scim.Email;
-import org.osiam.resources.scim.Group;
-import org.osiam.resources.scim.MemberRef;
-import org.osiam.resources.scim.UpdateGroup;
-import org.osiam.resources.scim.UpdateUser;
-import org.osiam.resources.scim.User;
+import org.osiam.resources.scim.*;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup("/database_seed_me_scope.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class MeScopeIT extends AbstractIntegrationTestBase {
@@ -166,8 +158,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
         OSIAM_CONNECTOR.getAllUsers(accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -176,8 +166,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         Query query = new QueryBuilder().filter("userName eq \"marissa\"").build();
 
         OSIAM_CONNECTOR.searchUsers(query, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -188,8 +176,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
                 .build();
 
         OSIAM_CONNECTOR.searchUsers(query, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -198,8 +184,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         User user = new User.Builder("newUser").build();
 
         OSIAM_CONNECTOR.createUser(user, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -207,8 +191,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
         OSIAM_CONNECTOR.getUser(OTHER_USER_ID, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -224,8 +206,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
                 .build();
 
         OSIAM_CONNECTOR.updateUser(OTHER_USER_ID, updateUser, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -242,8 +222,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
                 .build();
 
         OSIAM_CONNECTOR.replaceUser(OTHER_USER_ID, replaceUser, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -251,8 +229,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
         OSIAM_CONNECTOR.deleteUser(OTHER_USER_ID, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -260,8 +236,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
         OSIAM_CONNECTOR.getGroup(GROUP_ID, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -276,8 +250,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
                 .build();
 
         OSIAM_CONNECTOR.createGroup(group, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -289,8 +261,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
                 .build();
 
         OSIAM_CONNECTOR.updateGroup(GROUP_ID, updateGroup, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -305,8 +275,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
                 .build();
 
         OSIAM_CONNECTOR.replaceGroup(GROUP_ID, group, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -314,8 +282,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
         OSIAM_CONNECTOR.deleteGroup(GROUP_ID, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -323,8 +289,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
         OSIAM_CONNECTOR.getAllGroups(accessToken);
-
-        fail("Exception expected");
     }
 
     @Test(expected = ForbiddenException.class)
@@ -333,8 +297,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         Query query = new QueryBuilder().filter("displayName eq \"test_group01\"").build();
 
         OSIAM_CONNECTOR.searchGroups(query, accessToken);
-
-        fail("Exception expected");
     }
 
     @Test
@@ -396,7 +358,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.revokeAccessToken(accessToken);
 
         OSIAM_CONNECTOR.validateAccessToken(accessToken);
-        fail("Exception expected");
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -406,7 +367,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
         OSIAM_CONNECTOR.revokeAllAccessTokens(OWN_USER_ID, accessToken);
 
         OSIAM_CONNECTOR.validateAccessToken(accessToken);
-        fail("Exception expected");
     }
 
     @Test
@@ -425,7 +385,6 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
 
         OSIAM_CONNECTOR.revokeAllAccessTokens(OTHER_USER_ID, accessToken);
 
-        fail("Exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/MeUserServiceIT.java
+++ b/src/test/java/org/osiam/client/MeUserServiceIT.java
@@ -23,12 +23,10 @@
 
 package org.osiam.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osiam.client.exception.ConflictException;
@@ -41,15 +39,15 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 @DatabaseSetup("/database_seed_me_user.xml")
 public class MeUserServiceIT extends AbstractIntegrationTestBase {
@@ -84,8 +82,6 @@ public class MeUserServiceIT extends AbstractIntegrationTestBase {
     @Test(expected = ConflictException.class)
     public void get_current_user_while_logged_in_with_client_credential_raises_exception() throws Exception {
         OSIAM_CONNECTOR.getCurrentUserBasic(OSIAM_CONNECTOR.retrieveAccessToken(Scope.ADMIN));
-
-        fail("Exception expected");
     }
 
     @Test(expected = UnauthorizedException.class)

--- a/src/test/java/org/osiam/client/OAuthSecurityIT.java
+++ b/src/test/java/org/osiam/client/OAuthSecurityIT.java
@@ -23,17 +23,14 @@
 
 package org.osiam.client;
 
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.core.MediaType;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
@@ -45,8 +42,6 @@ public class OAuthSecurityIT extends AbstractIntegrationTestBase {
                 .path("example-client")
                 .request(MediaType.APPLICATION_JSON)
                 .get(String.class);
-
-        fail("Exception expected");
     }
 
     @Test(expected = NotAuthorizedException.class)
@@ -54,8 +49,6 @@ public class OAuthSecurityIT extends AbstractIntegrationTestBase {
         CLIENT.target(RESOURCE_ENDPOINT_ADDRESS + "/Users")
                 .request(MediaType.APPLICATION_JSON)
                 .get(String.class);
-
-        fail("Exception expected");
     }
 
     @Test(expected = NotAuthorizedException.class)
@@ -63,8 +56,6 @@ public class OAuthSecurityIT extends AbstractIntegrationTestBase {
         CLIENT.target(RESOURCE_ENDPOINT_ADDRESS + "/Groups")
                 .request(MediaType.APPLICATION_JSON)
                 .get(String.class);
-
-        fail("Exception expected");
     }
 
     @Test(expected = NotAuthorizedException.class)
@@ -72,7 +63,5 @@ public class OAuthSecurityIT extends AbstractIntegrationTestBase {
         CLIENT.target(RESOURCE_ENDPOINT_ADDRESS + "/Metrics")
                 .request(MediaType.APPLICATION_JSON)
                 .get(String.class);
-
-        fail("Exception expected");
     }
 }

--- a/src/test/java/org/osiam/client/ScimExtensionIT.java
+++ b/src/test/java/org/osiam/client/ScimExtensionIT.java
@@ -227,7 +227,6 @@ public class ScimExtensionIT extends AbstractIntegrationTestBase {
         User updatedUser = OSIAM_CONNECTOR.updateUser(EXISTING_USER_UUID, patchUser, accessToken);
 
         updatedUser.getExtension(URN);
-        fail("expected exception");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/UpdateGroupIT.java
+++ b/src/test/java/org/osiam/client/UpdateGroupIT.java
@@ -23,19 +23,10 @@
 
 package org.osiam.client;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,15 +41,18 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup("/database_seed.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class UpdateGroupIT extends AbstractIntegrationTestBase {
@@ -111,7 +105,6 @@ public class UpdateGroupIT extends AbstractIntegrationTestBase {
         createUpdateUserWithUpdateFields();
         idExistingGroup = UUID.randomUUID().toString();
         updateGroup();
-        fail("Exception expected");
     }
 
     @Test(expected = NoResultException.class)
@@ -120,7 +113,6 @@ public class UpdateGroupIT extends AbstractIntegrationTestBase {
         createUpdateUserWithUpdateFields();
         idExistingGroup = ID_USER_HSIMPSON;
         updateGroup();
-        fail("Exception expected");
     }
 
     @Test
@@ -150,7 +142,6 @@ public class UpdateGroupIT extends AbstractIntegrationTestBase {
         getOriginalGroup();
         createUpdateGroupWithAddingInvalidMembers();
         updateGroup();
-        fail("Exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/UserActivationLoginIT.java
+++ b/src/test/java/org/osiam/client/UserActivationLoginIT.java
@@ -23,8 +23,10 @@
 
 package org.osiam.client;
 
-import static org.junit.Assert.fail;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osiam.client.exception.ConnectionInitializationException;
@@ -34,15 +36,10 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup(value = "/database_seed_activation.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class UserActivationLoginIT extends AbstractIntegrationTestBase {
@@ -50,6 +47,5 @@ public class UserActivationLoginIT extends AbstractIntegrationTestBase {
     @Test(expected = ConnectionInitializationException.class)
     public void log_in_as_an_deactivated_user_is_impossible() {
         OSIAM_CONNECTOR.retrieveAccessToken("hsimpson", "koala", Scope.ADMIN);
-        fail("Exception expected");
     }
 }

--- a/src/test/java/org/osiam/client/UserServiceIT.java
+++ b/src/test/java/org/osiam/client/UserServiceIT.java
@@ -23,17 +23,10 @@
 
 package org.osiam.client;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.List;
-
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,15 +41,18 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseOperation;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/context.xml")
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-        DbUnitTestExecutionListener.class })
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DbUnitTestExecutionListener.class})
 @DatabaseSetup("/database_seed_users.xml")
 @DatabaseTearDown(value = "/database_tear_down.xml", type = DatabaseOperation.DELETE_ALL)
 public class UserServiceIT extends AbstractIntegrationTestBase {
@@ -138,7 +134,6 @@ public class UserServiceIT extends AbstractIntegrationTestBase {
         givenAnInvalidAccessToken();
 
         whenAValidUserIsDeserialized();
-        fail("Exception expected");
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -146,7 +141,6 @@ public class UserServiceIT extends AbstractIntegrationTestBase {
         givenAnAccessTokenForOneSecond();
         Thread.sleep(1000);
         whenAValidUserIsDeserialized();
-        fail("Exception expected");
     }
 
     protected void givenAnAccessTokenForOneSecond() {


### PR DESCRIPTION
This pull request adjusts the integration tests to work with the changes made in osiam/resource-server#65 while working on the exception handling I also made use of Junits `@Rule` notation to handle the expected exceptions.