### PR TITLE
Introduce `debug` Profile for Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,24 @@ If you are on mac or want to run them in a VM, just checkout the
 [OSIAM vagrant VM](https://github.com/osiam/vagrant). It's pretty easy to setup.
 Just run the above mentioned command in the OSIAM vagrant VM and run the
 integration-tests against the VM.
+
+## Cross Project Debugging
+
+If you want to use the integration tests to debug code in other OSIAM projects,
+you need to enable the `debug` profile. Please remember that this overrides
+the active-by-default setting for the `postgres` profile, so if you want to use
+it, run it like
+
+    $ mvn clean pre-integration-test -P postgres,debug
+
+This changes nothing for the `mysql` profile, so running
+
+    $ mvn clean pre-integration-test -P mysql,debug
+
+is equivalent.
+
+In your IDE containing the project you want to debug, you can now attach the debugger.
+Just use the normal remote debugging setup for your IDE and connect to `localhost:8000`.
+Set your breakpoints as usual and run the test in the ITs project.
+Your IDE should pop up as soon as the service reaches the breakpoint.
+

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
             1.4-SNAPSHOT
         </version.osiam.addon-self-administration-plugin-example>
         <version.osiam.connector4java>1.7-SNAPSHOT</version.osiam.connector4java>
+
+        <connector.timeout>10000</connector.timeout>
+        <debug.pre.command.tomcat></debug.pre.command.tomcat>
     </properties>
 
     <repositories>
@@ -687,6 +690,14 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>debug</id>
+            <properties>
+                <debug.pre.command.tomcat>"jpda",</debug.pre.command.tomcat>
+            </properties>
+
         </profile>
     </profiles>
 </project>

--- a/src/main/docker/tomcat/Dockerfile
+++ b/src/main/docker/tomcat/Dockerfile
@@ -13,4 +13,6 @@ RUN sed -i 's/8080/8180/g' $CATALINA_HOME/conf/server.xml
 RUN cp -p /usr/share/zoneinfo/${user.timezone} /etc/localtime
 RUN echo "${user.timezone}" > /etc/timezone
 
-EXPOSE 8180 11110
+EXPOSE 8180 11110 8000
+
+CMD [ "catalina.sh", ${debug.pre.command.tomcat} "run"]

--- a/src/main/docker/tomcat/conf.yml
+++ b/src/main/docker/tomcat/conf.yml
@@ -12,6 +12,7 @@ links:
 ports:
   - 8180
   - 11110
+  - 8000
 
 healthChecks:
   pings:

--- a/src/test/groovy/org/osiam/test/integration/AbstractIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/AbstractIT.groovy
@@ -62,8 +62,8 @@ abstract class AbstractIT extends Specification {
     protected AccessToken accessToken
 
     static {
-        OsiamConnector.setConnectTimeout(10000);
-        OsiamConnector.setReadTimeout(10000);
+        OsiamConnector.setConnectTimeout(Integer.parseInt(System.getProperty("connector.timeout", "-1")));
+        OsiamConnector.setReadTimeout(Integer.parseInt(System.getProperty("connector.timeout", "-1")));
 
         OSIAM_CONNECTOR = new OsiamConnector.Builder()
                 .setAuthServerEndpoint(AUTH_ENDPOINT)

--- a/src/test/java/org/osiam/client/AbstractIntegrationTestBase.java
+++ b/src/test/java/org/osiam/client/AbstractIntegrationTestBase.java
@@ -50,8 +50,8 @@ public abstract class AbstractIntegrationTestBase {
     protected static final Client CLIENT = ClientBuilder.newBuilder().register(JacksonFeature.class).build();
 
     static {
-        OsiamConnector.setConnectTimeout(10000);
-        OsiamConnector.setReadTimeout(30000);
+        OsiamConnector.setConnectTimeout(Integer.parseInt(System.getProperty("connector.timeout", "-1")));
+        OsiamConnector.setReadTimeout(Integer.parseInt(System.getProperty("connector.timeout", "-1")));
 
         OSIAM_CONNECTOR = new OsiamConnector.Builder()
                 .setAuthServerEndpoint(AUTH_ENDPOINT_ADDRESS)


### PR DESCRIPTION
Related to #282

This commit introduces the `debug` profile for the build. It allows to
debug the code of other OSIAM components, that are tested using the ITs.
Please refer to [0] for the technical background on this issue.

[0] https://github.com/osiam/connector4java-integration-tests/issues/282