### PR TITLE
Add Entry for Apache HTTP Client Logging

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -8,4 +8,5 @@ log4j.appender.S.layout = org.apache.log4j.PatternLayout
 log4j.appender.S.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c [%p] %m%n
 
 #log4j.logger.org.osiam.bundled.org.apache.http.wire=DEBUG
+#log4j.logger.org.apache.http.wire=DEBUG
 #log4j.logger.org.osiam.bundled.org.apache.http.headers=DEBUG


### PR DESCRIPTION
This adds an commented entry to the `log4j.properties` that can be used
to see the HTTP traffic between the tests and the services.