### PR TITLE
Create junit report folder per running node on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,5 +17,5 @@ test:
     - /bin/bash circle.sh:
         parallel: true
   post:
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-    - find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - /bin/bash report.sh:
+        parallel: true

--- a/report.sh
+++ b/report.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+mkdir -p $CIRCLE_TEST_REPORTS/junit/
+find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;


### PR DESCRIPTION
Before the last finished test node is overwritten the files in the junit reports folder. Now for every node a report folder is created.