### PR TITLE
Update dependencies to Java 8 and Tomcat 8

### DIFF
--- a/src/main/docker/ldap/Dockerfile
+++ b/src/main/docker/ldap/Dockerfile
@@ -1,4 +1,4 @@
-FROM osixia/openldap:1.0.1
+FROM osixia/openldap:1.0.9
 
 ENV LDAP_ORGANISATION="OSIAM ITs"
 ENV LDAP_DOMAIN=osiam.org

--- a/src/main/docker/postgres/Dockerfile
+++ b/src/main/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.3
+FROM postgres:9.4
 
 RUN cp -p /usr/share/zoneinfo/${user.timezone} /etc/localtime
 RUN echo "${user.timezone}" > /etc/timezone

--- a/src/main/docker/tomcat/Dockerfile
+++ b/src/main/docker/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:7-jre7
+FROM tomcat:8-jre8
 
 COPY osiam $CATALINA_HOME/webapps/osiam
 COPY addon-self-administration $CATALINA_HOME/webapps/addon-self-administration


### PR DESCRIPTION
In preparation to upgrade the java dependencies of OSIAM to version 8
this commit updates the docker images to use Java 8 and Tomcat 8. It
also updates the PostgreSQL version used to 9.4.

This pull request has to be merged before work can start on the issue
osiam/osiam#10