### PR TITLE
Re-enable possibility to attach debugger.

### DIFF
--- a/src/main/docker/tomcat/Dockerfile
+++ b/src/main/docker/tomcat/Dockerfile
@@ -9,6 +9,7 @@ COPY greenmail-webapp-1.4.1 $CATALINA_HOME/webapps/greenmail-webapp
 
 RUN cat /install/selfadminexample.properties >> $CATALINA_HOME/conf/catalina.properties
 RUN sed -i 's/8080/8180/g' $CATALINA_HOME/conf/server.xml
+RUN echo "JPDA_ADDRESS=8000" > $CATALINA_HOME/bin/setenv.sh
 RUN cp -p /usr/share/zoneinfo/${user.timezone} /etc/localtime
 RUN echo "${user.timezone}" > /etc/timezone
 


### PR DESCRIPTION
With the upgrade to Tomcat 8 the default behaviour with regard to the
jpda debugging port changed: Tomcat only binds to localhost, this commit
remedies that and makes it possible again to debug the integration
tests.