### PR TITLE
Handle 400 BAD REQUEST for invalid filters.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     DOCKER_HOST: tcp://localhost:2375
   java:
-    version: openjdk7
+    version: oraclejdk8
   pre:
     - echo 'DOCKER_OPTS="${DOCKER_OPTS} -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"' | sudo tee -a /etc/default/docker
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.osiam.addon-self-administration-plugin-example>
             1.4-SNAPSHOT
         </version.osiam.addon-self-administration-plugin-example>
-        <version.osiam.connector4java>1.8</version.osiam.connector4java>
+        <version.osiam.connector4java>1.9-SNAPSHOT</version.osiam.connector4java>
     </properties>
 
     <dependencies>

--- a/src/test/groovy/org/osiam/test/integration/ComplexSearchIncludingNotIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/ComplexSearchIncludingNotIT.groovy
@@ -23,6 +23,7 @@
 
 package org.osiam.test.integration
 
+import org.osiam.client.exception.BadRequestException
 import org.osiam.client.exception.ConflictException
 import org.osiam.client.query.Query
 import org.osiam.client.query.QueryBuilder
@@ -94,6 +95,6 @@ class ComplexSearchIncludingNotIT extends AbstractIT {
         OSIAM_CONNECTOR.searchUsers(query, accessToken)
 
         then:
-        thrown(ConflictException)
+        thrown(BadRequestException)
     }
 }

--- a/src/test/groovy/org/osiam/test/integration/ScimExtensionSearchIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/ScimExtensionSearchIT.groovy
@@ -23,7 +23,7 @@
 
 package org.osiam.test.integration
 
-import org.osiam.client.exception.ConflictException
+import org.osiam.client.exception.BadRequestException
 import org.osiam.client.query.Query
 import org.osiam.client.query.QueryBuilder
 import org.osiam.resources.scim.SCIMSearchResult
@@ -105,7 +105,7 @@ public class ScimExtensionSearchIT extends AbstractExtensionBaseIT {
         OSIAM_CONNECTOR.searchUsers(query, accessToken)
 
         then:
-        thrown(ConflictException)
+        thrown(BadRequestException)
 
         where:
         fieldType            | fieldName            | constraint

--- a/src/test/groovy/org/osiam/test/integration/ScimExtensionTypesIT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/ScimExtensionTypesIT.groovy
@@ -25,9 +25,8 @@ package org.osiam.test.integration
 
 import groovyx.net.http.HTTPBuilder
 import groovyx.net.http.Method
-
+import org.osiam.client.exception.BadRequestException
 import org.osiam.client.oauth.Scope
-import org.osiam.client.exception.ConflictException
 import org.osiam.resources.scim.Extension
 import org.osiam.resources.scim.User
 import spock.lang.Unroll
@@ -49,7 +48,7 @@ class ScimExtensionTypesIT extends AbstractExtensionBaseIT {
         OSIAM_CONNECTOR.createUser(userBuilder.build(), accessToken)
 
         then:
-        thrown(ConflictException)
+        thrown(BadRequestException)
 
         where:
         fieldName            | fieldType            | fieldValue

--- a/src/test/groovy/org/osiam/test/integration/regression/Bug66IT.groovy
+++ b/src/test/groovy/org/osiam/test/integration/regression/Bug66IT.groovy
@@ -1,0 +1,31 @@
+package org.osiam.test.integration.regression
+
+import org.osiam.client.exception.BadRequestException
+import org.osiam.client.query.QueryBuilder
+import org.osiam.test.integration.AbstractIT
+import spock.lang.Unroll
+
+class Bug66IT extends AbstractIT {
+
+    def setup() {
+        setupDatabase('/database_seed.xml')
+    }
+
+    @Unroll
+    def "Invalid query '#filter' generates a 400 BAD REQUEST"() {
+        given:
+        def query = new QueryBuilder().filter(filter).build()
+
+        when:
+        OSIAM_CONNECTOR.searchUsers(query, accessToken)
+
+        then:
+        thrown(BadRequestException)
+
+        where:
+        filter << ["userName = \"marissa\"",
+                   "userName eq \"marissa\" and name.formatted = \"Formatted Name\"",
+                   "userName = \"marissa\" and name.formatted = \"Formatted Name\""]
+
+    }
+}

--- a/src/test/java/org/osiam/client/EditGroupServiceIT.java
+++ b/src/test/java/org/osiam/client/EditGroupServiceIT.java
@@ -30,6 +30,7 @@ import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.osiam.client.exception.BadRequestException;
 import org.osiam.client.exception.ConflictException;
 import org.osiam.client.exception.NoResultException;
 import org.osiam.client.oauth.Scope;
@@ -66,13 +67,13 @@ public class EditGroupServiceIT extends AbstractIntegrationTestBase {
         accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
     }
 
-    @Test(expected = ConflictException.class)
+    @Test(expected = BadRequestException.class)
     public void create_group_without_displayName_raises_exception() {
         group = new Group.Builder().build();
         OSIAM_CONNECTOR.createGroup(group, accessToken);
     }
 
-    @Test(expected = ConflictException.class)
+    @Test(expected = BadRequestException.class)
     public void create_group_with_empty_displayName_raises_exception() {
         group = new Group.Builder("").build();
         OSIAM_CONNECTOR.createGroup(group, accessToken);

--- a/src/test/java/org/osiam/client/EditUserServiceIT.java
+++ b/src/test/java/org/osiam/client/EditUserServiceIT.java
@@ -30,6 +30,7 @@ import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.osiam.client.exception.BadRequestException;
 import org.osiam.client.exception.ConflictException;
 import org.osiam.client.exception.NoResultException;
 import org.osiam.client.exception.UnauthorizedException;
@@ -73,7 +74,7 @@ public class EditUserServiceIT extends AbstractIntegrationTestBase {
         accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
     }
 
-    @Test(expected = ConflictException.class)
+    @Test(expected = BadRequestException.class)
     public void create_user_with_no_username_raises_exception() {
         initializeUserWithNoUserName();
         createUser();

--- a/src/test/java/org/osiam/client/ErrorMessagesIT.java
+++ b/src/test/java/org/osiam/client/ErrorMessagesIT.java
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.osiam.client.exception.BadRequestException;
 import org.osiam.client.exception.ConflictException;
 import org.osiam.client.exception.NoResultException;
 import org.osiam.client.exception.UnauthorizedException;
@@ -69,7 +70,7 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
     /**
      * example message: User with id '81b2be7e-9e2c-40ce-af3c-0567ce904166' not found
      */
-    @Test
+
     public void retrieving_non_existing_User_returns_correct_error_message() {
         thrown.expect(NoResultException.class);
         thrown.expectMessage(startsWith("User"));
@@ -107,7 +108,7 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_user_without_userName_returns_correct_error_message() {
-        thrown.expect(ConflictException.class);
+        thrown.expect(BadRequestException.class);
         thrown.expectMessage(containsString("userName"));
         thrown.expectMessage(containsString("mandatory"));
 
@@ -120,7 +121,7 @@ public class ErrorMessagesIT extends AbstractIntegrationTestBase {
      */
     @Test
     public void create_group_without_displayName_returns_correct_error_message() {
-        thrown.expect(ConflictException.class);
+        thrown.expect(BadRequestException.class);
         thrown.expectMessage(containsString("displayName"));
         thrown.expectMessage(containsString("mandatory"));
 

--- a/src/test/java/org/osiam/client/SearchUserServiceIT.java
+++ b/src/test/java/org/osiam/client/SearchUserServiceIT.java
@@ -33,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.osiam.client.exception.BadRequestException;
 import org.osiam.client.exception.ConflictException;
 import org.osiam.client.oauth.Scope;
 import org.osiam.client.query.Query;
@@ -142,7 +143,7 @@ public class SearchUserServiceIT extends AbstractIntegrationTestBase {
     @DatabaseSetup("/database_seeds/SearchUserServiceIT/user_by_email.xml")
     public void search_with_double_quotes_less_value_returns_correct_exception_message() {
 
-        thrown.expect(ConflictException.class);
+        thrown.expect(BadRequestException.class);
         thrown.expectMessage(containsString("Please make sure that all values are surrounded by double quotes"));
 
         String email = "bjensen@example.com";
@@ -309,7 +310,7 @@ public class SearchUserServiceIT extends AbstractIntegrationTestBase {
         assertThat(user.getUserName(), is("marissa"));
     }
 
-    @Test(expected = ConflictException.class)
+    @Test(expected = BadRequestException.class)
     @DatabaseSetup("/database_seeds/SearchUserServiceIT/database_seed.xml")
     public void search_for_user_by_non_exisitng_field_with_query_string_fails() {
         Query query = new QueryBuilder().filter(INVALID_STRING + " eq \"" + INVALID_STRING + "\"").build();


### PR DESCRIPTION
Invalid filter strings generate a 400 BAD REQUEST now instead of a 409
CONFLICT this pull request adjusts the integration tests to prepare for that.

This pull request is needed to make the ITs work again after accepting osiam/osiam#125