### PR TITLE
Downgrade docker-maven-plugin to 2.10.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <debug.pre.command.tomcat/>
 
         <version.spring>4.2.4.RELEASE</version.spring>
-        <version.docker-maven-plugin>2.11.9</version.docker-maven-plugin>
+        <version.docker-maven-plugin>2.10.6</version.docker-maven-plugin>
 
         <!-- OSIAM -->
         <version.osiam>3.0-SNAPSHOT</version.osiam>


### PR DESCRIPTION
There seem to be some issues with the 2.11.x version of the docker-maven-plugin. These have to be investigated further, but apply the downgrade as a quick workaround, so that development can continue.