### PR TITLE
Remove old /Me resource

### DIFF
--- a/src/test/java/org/osiam/client/AdminScopeIT.java
+++ b/src/test/java/org/osiam/client/AdminScopeIT.java
@@ -189,19 +189,10 @@ public class AdminScopeIT extends AbstractIntegrationTestBase {
     }
 
     @Test
-    public void can_get_me_basic() {
-        AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
-
-        BasicUser user = OSIAM_CONNECTOR.getCurrentUserBasic(accessToken);
-
-        assertThat(user.getUserName(), is(equalTo("marissa")));
-    }
-
-    @Test
     public void can_get_me() {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
 
-        User user = OSIAM_CONNECTOR.getCurrentUser(accessToken);
+        User user = OSIAM_CONNECTOR.getMe(accessToken);
 
         assertThat(user.getUserName(), is(equalTo("marissa")));
     }

--- a/src/test/java/org/osiam/client/LoginOAuth2IT.java
+++ b/src/test/java/org/osiam/client/LoginOAuth2IT.java
@@ -288,7 +288,7 @@ public class LoginOAuth2IT extends AbstractIntegrationTestBase {
         givenValidAuthCode("marissa", "koala", "internal");
         givenAuthCode();
         givenAccessTokenUsingAuthCode();
-        User user = OSIAM_CONNECTOR.getCurrentUser(accessToken);
+        User user = OSIAM_CONNECTOR.getMe(accessToken);
         assertEquals("marissa", user.getUserName());
     }
 

--- a/src/test/java/org/osiam/client/MeScopeIT.java
+++ b/src/test/java/org/osiam/client/MeScopeIT.java
@@ -37,7 +37,12 @@ import org.osiam.client.oauth.Scope;
 import org.osiam.client.query.Query;
 import org.osiam.client.query.QueryBuilder;
 import org.osiam.client.user.BasicUser;
-import org.osiam.resources.scim.*;
+import org.osiam.resources.scim.Email;
+import org.osiam.resources.scim.Group;
+import org.osiam.resources.scim.MemberRef;
+import org.osiam.resources.scim.UpdateGroup;
+import org.osiam.resources.scim.UpdateUser;
+import org.osiam.resources.scim.User;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -123,19 +128,10 @@ public class MeScopeIT extends AbstractIntegrationTestBase {
     }
 
     @Test
-    public void can_get_me_basic() {
-        AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
-
-        BasicUser user = OSIAM_CONNECTOR.getCurrentUserBasic(accessToken);
-
-        assertThat(user.getUserName(), is(equalTo("marissa")));
-    }
-
-    @Test
     public void can_get_me() {
         AccessToken accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ME);
 
-        User user = OSIAM_CONNECTOR.getCurrentUser(accessToken);
+        User user = OSIAM_CONNECTOR.getMe(accessToken);
 
         assertThat(user.getUserName(), is(equalTo("marissa")));
     }

--- a/src/test/java/org/osiam/client/MeUserServiceIT.java
+++ b/src/test/java/org/osiam/client/MeUserServiceIT.java
@@ -29,6 +29,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.osiam.client.exception.BadRequestException;
 import org.osiam.client.exception.ConflictException;
 import org.osiam.client.exception.UnauthorizedException;
 import org.osiam.client.oauth.Scope;
@@ -53,35 +54,18 @@ import static org.junit.Assert.assertEquals;
 public class MeUserServiceIT extends AbstractIntegrationTestBase {
 
     @Test
-    public void get_current_user_basic_returns_correct_user() throws Exception {
-        accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
-
-        BasicUser basicUser = OSIAM_CONNECTOR.getCurrentUserBasic(accessToken);
-
-        assertEquals("cef9452e-00a9-4cec-a086-d171374ffbef", basicUser.getId());
-        assertEquals("marissa", basicUser.getUserName());
-        assertEquals("marissa@example.com", basicUser.getEmail());
-        assertEquals("Marissa", basicUser.getFirstName());
-        assertEquals("Thompson", basicUser.getLastName());
-        assertEquals("", basicUser.getLocale());
-        SimpleDateFormat sdfToDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        Date date = sdfToDate.parse("2011-10-10 00:00:00");
-        assertEquals(date, basicUser.getUpdatedTime());
-    }
-
-    @Test
     public void get_current_user_returns_correct_user() throws Exception {
         accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
 
-        User user = OSIAM_CONNECTOR.getCurrentUser(accessToken);
+        User user = OSIAM_CONNECTOR.getMe(accessToken);
 
         assertEquals("cef9452e-00a9-4cec-a086-d171374ffbef", user.getId());
         assertEquals("marissa", user.getUserName());
     }
 
-    @Test(expected = ConflictException.class)
+    @Test(expected = BadRequestException.class)
     public void get_current_user_while_logged_in_with_client_credential_raises_exception() throws Exception {
-        OSIAM_CONNECTOR.getCurrentUserBasic(OSIAM_CONNECTOR.retrieveAccessToken(Scope.ADMIN));
+        OSIAM_CONNECTOR.getMe(OSIAM_CONNECTOR.retrieveAccessToken(Scope.ADMIN));
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -89,6 +73,6 @@ public class MeUserServiceIT extends AbstractIntegrationTestBase {
         accessToken = OSIAM_CONNECTOR.retrieveAccessToken("marissa", "koala", Scope.ADMIN);
         OSIAM_CONNECTOR.deleteUser("cef9452e-00a9-4cec-a086-d171374ffbef", accessToken);
 
-        OSIAM_CONNECTOR.getCurrentUserBasic(accessToken);
+        OSIAM_CONNECTOR.getMe(accessToken);
     }
 }


### PR DESCRIPTION
Since OSIAM reworked the '/Me' resource to be SCIM 2 compliant the
integration tests have to be adjusted accordingly. This drops tests
using the `BasicUser` and use the Connectors' new  `getMe()` method
instead of the old `getCurrentUser()` method. It requires the 
corresponding pull request osiam/osiam#185 to be merged to work.