### PR TITLE
Create extensions in the configuration

### DIFF
--- a/src/test/docker/osiam/osiam_mysql.yaml
+++ b/src/test/docker/osiam/osiam_mysql.yaml
@@ -15,6 +15,23 @@ osiam:
     password: b4s3dg0d
 
   #
+  # SCIM Extensions
+  #
+  scim:
+    extensions:
+      - urn: exampleExtension1
+        fields:
+          - name: requiredStringField
+            type: STRING
+            required: yes
+          - name: integerField
+            type: INTEGER
+      - urn: exampleExtension2
+        fields:
+          - name: booleanField
+            type: BOOLEAN
+
+  #
   # LDAP configuration
   #
   ldap:

--- a/src/test/docker/osiam/osiam_postgres.yaml
+++ b/src/test/docker/osiam/osiam_postgres.yaml
@@ -15,6 +15,23 @@ osiam:
     password: b4s3dg0d
 
   #
+  # SCIM Extensions
+  #
+  scim:
+    extensions:
+      - urn: exampleExtension1
+        fields:
+          - name: requiredStringField
+            type: STRING
+            required: yes
+          - name: integerField
+            type: INTEGER
+      - urn: exampleExtension2
+        fields:
+          - name: booleanField
+            type: BOOLEAN
+
+  #
   # LDAP configuration
   #
   ldap:


### PR DESCRIPTION
This is thought to be a very basic test, whether the configuration of
extensions is working. If something is very wrong, OSIAM would not start
and all tests would fail. Unfortunately, we cannot test, whether the
extensions have really been created, because DBUnit clears the complete
database on every test run.

Part of osiam/osiam#209