### PR TITLE
Remove Evolvis releases repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The integration-tests for OSIAM.
 You can run the integration-tests on your machine, you only need to install
 java, maven and docker, and configure docker.
 
-The tests will fetch the snapshot dependencies from evolvis or you clone the
+The tests will fetch the snapshot dependencies from OSS JFrog or you clone the
 following repos and install them with ```mvn clean install```
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -235,13 +235,6 @@
 
     <repositories>
         <repository>
-            <id>osiam-releases</id>
-            <url>https://maven-repo.evolvis.org/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>osiam-snapshots</id>
             <url>https://oss.jfrog.org/artifactory/repo/</url>
             <releases>


### PR DESCRIPTION
There are no releases on the Evolvis releases repo, that we wouldn't get
from the central too.