### PR TITLE
Update LDAP Docker image to latest version

### DIFF
--- a/src/test/docker/ldap/Dockerfile
+++ b/src/test/docker/ldap/Dockerfile
@@ -1,4 +1,4 @@
-FROM osixia/openldap:1.0.9
+FROM osixia/openldap:1.1.6
 
 ENV LDAP_ORGANISATION="OSIAM ITs"
 ENV LDAP_DOMAIN=osiam.org


### PR DESCRIPTION
The currently used version does not exist on the Docker Hub anymore.